### PR TITLE
export INTENT_EXTRA_NAME_ASSET_LIST to allow clients to construct their own intents

### DIFF
--- a/KitePrintSDK/src/main/java/ly/kite/product/ProductCreationActivity.java
+++ b/KitePrintSDK/src/main/java/ly/kite/product/ProductCreationActivity.java
@@ -83,7 +83,7 @@ public class ProductCreationActivity extends AKiteActivity implements FragmentMa
   @SuppressWarnings( "unused" )
   private static final String  LOG_TAG                         = "ProductSelectionAct.";  // Can't be more than 23 characters ... who knew?!
 
-  private static final String  INTENT_EXTRA_NAME_ASSET_LIST    = KiteSDK.INTENT_PREFIX + ".AssetList";
+  public static final String  INTENT_EXTRA_NAME_ASSET_LIST     = KiteSDK.INTENT_PREFIX + ".AssetList";
 
 
   ////////// Static Variable(s) //////////


### PR DESCRIPTION
The reason behind allowing clients to construct their own intents sent to ProductCreationActivity,
is to enable clients to call whatever startActivity\* method needed.
Some need startActivityForResult, others need startActivityFromFragment,
and then there is the issue of different Fragment classes from the Support library, and so on.
By exporting the expected keys in intents received by ProductCreationActivity,
we can cater to the myriad different ways clients would like to start ProductCreationActivity.
