### PR TITLE
Fix for: Add resourcePrefix to prevent resource naming clashes #162

### DIFF
--- a/DevicePhotoPicker/build.gradle
+++ b/DevicePhotoPicker/build.gradle
@@ -27,6 +27,9 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    resourcePrefix 'kitesdk_'
+
 }
 
 dependencies {

--- a/FacebookPhotoPicker/build.gradle
+++ b/FacebookPhotoPicker/build.gradle
@@ -29,6 +29,8 @@ android {
         }
     }
 
+    resourcePrefix 'kitesdk_'
+
 }
 
 dependencies {

--- a/ImagePicker/build.gradle
+++ b/ImagePicker/build.gradle
@@ -35,6 +35,9 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    resourcePrefix 'kitesdk_'
+
 }
 
 dependencies {

--- a/InstagramPhotoPicker/build.gradle
+++ b/InstagramPhotoPicker/build.gradle
@@ -22,6 +22,9 @@ android {
         versionCode 1
         versionName "1.0"
     }
+
+    resourcePrefix 'kitesdk_'
+
 }
 
 dependencies {

--- a/KitePrintSDK-GCM/build.gradle
+++ b/KitePrintSDK-GCM/build.gradle
@@ -30,6 +30,9 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    resourcePrefix 'kitesdk_'
+
 }
 
 dependencies {

--- a/KitePrintSDK/build.gradle
+++ b/KitePrintSDK/build.gradle
@@ -42,6 +42,9 @@ android {
             testCoverageEnabled true
         }
     }
+
+    resourcePrefix 'kitesdk_'
+
 }
 
 dependencies {


### PR DESCRIPTION
Following the suggestions from Numan1617. I have added resource prefixes to all gradle files. 